### PR TITLE
Fix ggplot deprecation warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,10 @@
 Package: plotluck
 Title: 'ggplot2' Version of "I'm Feeling Lucky!"
-Version: 1.1.1
-Authors@R: person("Stefan", "Schroedl", , "stefan.schroedl@gmx.de", c("aut", "cre"))
+Version: 1.1.1.9000
+Authors@R: c(
+   person("Stefan", "Schroedl", , "stefan.schroedl@gmx.de", c("aut", "cre")),
+   person(given = "Christophe", family = "Regouby", email = "christophe.regouby@free.fr", role = c("ctb"))
+           )
 Description: Examines the characteristics of a data frame and a formula to
     automatically choose the most suitable type of plot out of the following supported
     options: scatter, violin, box, bar, density, hexagon bin, spine plot, and
@@ -15,12 +18,10 @@ Depends:
 Imports:
     grid,
     Hmisc (>= 3.17.4),
-    quantreg (>= 5.26),
     scales (>= 0.4.1),
     plyr (>= 1.8.4),
-    hexbin (>= 1.27.1),
     RColorBrewer (>= 1.1.2),
-    ggplot2 (>= 2.2.0)
+    ggplot2 (>= 3.4.0)
 License: MIT + file LICENSE
 URL: https://github.com/stefan-schroedl/plotluck
 BugReports: https://github.com/stefan-schroedl/plotluck/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Development version
+* Compatibility with ggplot 3.4.0 (#5 @cregouby)
+
 # plotluck 1.1.1
 * Rerun roxygen2 for documentation format compliance
 * Move example image in readme file to avoid warning

--- a/R/plotluck.R
+++ b/R/plotluck.R
@@ -1927,22 +1927,22 @@ sample.data <- function(data, w='NULL', max.rows) {
 # expected input formula: 'x', 'x*y', 'x+y', 'x+1'
 # output: list of occurring variables, ignoring constants
 parse.formula.term <- function(form) {
-  if (class(form) == 'numeric') {
+  if (inherits(form, 'numeric')) {
     return(character())
   }
-  if (class(form) == 'name') {
+  if (inherits(form, 'name')) {
     return(as.character(form))
   }
   if (as.character(form[[1]]) %in% c('+', '*')) {
     res <- character()
-    if (class(form[[2]]) == 'name') {
+    if (inherits(form[[2]], 'name')) {
       res <- as.character(form[[2]])
-    } else if (class(form[[2]]) != 'numeric') {
+    } else if (!inherits(form[[2]], 'numeric')) {
       stop('Invalid formula: at most two dependent or conditional variables allowed')
     }
-    if (class(form[[3]]) == 'name') {
+    if (inherits(form[[3]], 'name')) {
       res <- c(res, as.character(form[[3]]))
-    } else if (class(form[[3]]) != 'numeric') {
+    } else if (!inherits(form[[3]], 'numeric')) {
       stop('Invalid formula: at most two dependent or conditional variables allowed')
     }
     return(res)
@@ -1957,7 +1957,7 @@ parse.formula <- function(form) {
     stop('Invalid formula')
   }
   node <- form[[2]]
-  if (class(node) != 'name') {
+  if (!inherits(node,'name')) {
     stop('Invalid formula: only one dependent variable allowed')
   }
   resp <- as.character(node)
@@ -1965,7 +1965,7 @@ parse.formula <- function(form) {
   cond <- character()
 
   node <- form[[3]]
-  if (class(node) != 'name' && as.character(node[[1]])  == '|') {
+  if (!inherits(node,'name') && as.character(node[[1]])  == '|') {
     indep <- parse.formula.term(node[[2]])
     cond <- parse.formula.term(node[[3]])
   } else {

--- a/R/plotluck.R
+++ b/R/plotluck.R
@@ -886,7 +886,7 @@ add.color.legend <- function(p, data, x, aesth=c('color','fill')) {
   if (is.numeric(data[[x]])) {
     # color bars always on the right margin, to avoid number label overwriting
     if (aesth == 'color') {
-      p <- p + guides(color=guide_colorbar(direction='vertical'), fill=FALSE)
+      p <- p + guides(color=guide_colorbar(direction='vertical'), fill='none')
     } else {
       p <- p + guides(fill=guide_colorbar(direction='vertical'), color='none')
     }
@@ -923,7 +923,7 @@ add.color.legend <- function(p, data, x, aesth=c('color','fill')) {
     # vertical - by column, starting with first level at the bottom
     if (aesth == 'color') {
       p <- p + guides(color=guide_legend(direction='vertical', byrow=FALSE,
-                                         reverse=TRUE, ncol=ncol.vert), fill=FALSE)
+                                         reverse=TRUE, ncol=ncol.vert), fill='none')
     } else {
       p <- p + guides(fill=guide_legend(direction='vertical', byrow=FALSE,
                                         reverse=TRUE, ncol=ncol.vert), color='none')
@@ -933,7 +933,7 @@ add.color.legend <- function(p, data, x, aesth=c('color','fill')) {
     # horizontal - by row
     if (aesth == 'color') {
       p <- p + guides(color=guide_legend(direction='horizontal', byrow=TRUE,
-                                         reverse=FALSE, nrow=nrow.horz), fill=FALSE)
+                                         reverse=FALSE, nrow=nrow.horz), fill='none')
     } else {
       p <- p + guides(fill=guide_legend(direction='horizontal', byrow=TRUE,
                                         reverse=FALSE, nrow=nrow.horz), color='none')

--- a/R/plotluck.R
+++ b/R/plotluck.R
@@ -1130,7 +1130,7 @@ gplt.scatter <- function(data, x, y, w='NULL',
     # use point size to represent count/weight
     p <- p + geom_point(aes_string(size=w), alpha=alpha,
                         position=pos, na.rm=TRUE, ...) +
-      scale_size(guide=FALSE)
+      scale_size(guide='none')
   } else {
     # use jittering
     if (max(table(data[, c(x, y)], useNA='ifany')) >= min.points.jitter) {
@@ -1215,7 +1215,7 @@ gplt.hex <- function(data, x, y, w='NULL', trans.log.thresh=2,
 
   p <- p +
     # log scaling of color often reveals more details
-    scale_fill_gradientn(colors=c(hcl(66,60,95), hcl(128,100,45)), trans='log', guide=FALSE) +
+    scale_fill_gradientn(colors=c(hcl(66,60,95), hcl(128,100,45)), trans='log', guide='none') +
     theme(legend.position='right') +
     theme_panel_num_x + theme_panel_num_y
 
@@ -1540,7 +1540,7 @@ gplt.density <- function(data, x, w='NULL',
    }
 
    p <- ggplot(data, aes_string(x=x, weight=w)) +
-      geom_density(aes_(y=~..scaled..), alpha=0.6, adjust=0.5, trim=TRUE, na.rm=TRUE, ...) +
+      geom_density(aes_(y = ~after_stat(scaled)), alpha = 0.6, adjust = 0.5, trim = TRUE, na.rm = TRUE, ...) +
       geom_rug(na.rm=TRUE)
       # unfortunately the following does not work for log transformation -
       # the layer received the transformed data + geom_vline_center()
@@ -2774,7 +2774,7 @@ redundant.factor.color <- function(p, data, response, indep, type.plot, opts) {
     p <- add.color.fill(p, data, fac,
                         palette.brewer.seq=opts$palette.brewer.seq,
                         palette.brewer.qual=opts$palette.brewer.qual)  +
-      guides(fill=FALSE, color=FALSE)
+      guides(fill='none', color='none')
 
     return (p)
   } else if (type.plot %in% c('density', 'histogram')) {
@@ -2783,7 +2783,7 @@ redundant.factor.color <- function(p, data, response, indep, type.plot, opts) {
       aes(color='something') +
       scale_fill_manual(values=opts$fill.default) +
       scale_color_manual(values=opts$fill.default) +
-      guides(fill=FALSE, color=FALSE)
+      guides(fill='none', color='none')
   } else {
     p
   }

--- a/R/plotluck.R
+++ b/R/plotluck.R
@@ -888,7 +888,7 @@ add.color.legend <- function(p, data, x, aesth=c('color','fill')) {
     if (aesth == 'color') {
       p <- p + guides(color=guide_colorbar(direction='vertical'), fill=FALSE)
     } else {
-      p <- p + guides(fill=guide_colorbar(direction='vertical'), color=FALSE)
+      p <- p + guides(fill=guide_colorbar(direction='vertical'), color='none')
     }
     p <-  p + theme(legend.position='right', legend.background=element_blank())
     return(p)
@@ -926,7 +926,7 @@ add.color.legend <- function(p, data, x, aesth=c('color','fill')) {
                                          reverse=TRUE, ncol=ncol.vert), fill=FALSE)
     } else {
       p <- p + guides(fill=guide_legend(direction='vertical', byrow=FALSE,
-                                        reverse=TRUE, ncol=ncol.vert), color=FALSE)
+                                        reverse=TRUE, ncol=ncol.vert), color='none')
     }
     p + theme(legend.position='right', legend.background=element_blank())
   } else {
@@ -936,7 +936,7 @@ add.color.legend <- function(p, data, x, aesth=c('color','fill')) {
                                          reverse=FALSE, nrow=nrow.horz), fill=FALSE)
     } else {
       p <- p + guides(fill=guide_legend(direction='horizontal', byrow=TRUE,
-                                        reverse=FALSE, nrow=nrow.horz), color=FALSE)
+                                        reverse=FALSE, nrow=nrow.horz), color='none')
     }
     p + theme(legend.position='bottom', legend.background=element_blank())
   }
@@ -1540,7 +1540,7 @@ gplt.density <- function(data, x, w='NULL',
    }
 
    p <- ggplot(data, aes_string(x=x, weight=w)) +
-      geom_density(aes_(y = ~after_stat(scaled)), alpha = 0.6, adjust = 0.5, trim = TRUE, na.rm = TRUE, ...) +
+      geom_density(aes_(y=~after_stat(scaled)), alpha=0.6, adjust=0.5, trim=TRUE, na.rm=TRUE, ...) +
       geom_rug(na.rm=TRUE)
       # unfortunately the following does not work for log transformation -
       # the layer received the transformed data + geom_vline_center()


### PR DESCRIPTION
- fix #3 and fix #4
- fix R CMD check() note about `if (class("") == )`
- remove unused dependancies 

# New output with this P.R.
doesn't provide any obsolescence message  : 
``` r
plotluck::plotluck(mtcars, mpg~.)
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric =
#> parametric, : pseudoinverse used at 4
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric =
#> parametric, : neighborhood radius 2
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric =
#> parametric, : reciprocal condition number 1.8444e-17
#> Warning in predLoess(object$y, object$x, newx = if
#> (is.null(newdata)) object$x else if (is.data.frame(newdata))
#> as.matrix(model.frame(delete.response(terms(object)), : pseudoinverse used at 4
#> Warning in predLoess(object$y, object$x, newx = if
#> (is.null(newdata)) object$x else if (is.data.frame(newdata))
#> as.matrix(model.frame(delete.response(terms(object)), : neighborhood radius 2
#> Warning in predLoess(object$y, object$x, newx = if
#> (is.null(newdata)) object$x else if (is.data.frame(newdata))
#> as.matrix(model.frame(delete.response(terms(object)), : reciprocal condition
#> number 1.8444e-17
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
```

![](https://i.imgur.com/auAiPQb.png)<!-- -->

<sup>Created on 2023-01-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

# CMD check result : 
```
── R CMD check results ───────────────────────────────────────────────────────────────────────────────── plotluck 1.1.1.9000 ────
Duration: 1m 26.5s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔

R CMD check succeeded
```